### PR TITLE
Add GitHub workflow for automated releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Package and Release
+
+# Run on new tags
+on:
+  push:
+    tags:
+      - '**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  # secret is automatically provided to the workflow
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # gets git history for changelogs
+
+      - name: BigWigs Packager
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -p 404939 -w 26325

--- a/ShutUpUnta.toc
+++ b/ShutUpUnta.toc
@@ -2,7 +2,7 @@
 ## Title: |cffffc700[|cffff8000Shut Up Unta|cffffc700]|r
 ## DefaultState: enabled
 ## Author: defaude
-## Version: 1.0.10
+## Version: @project-version@
 ## Notes: All it does is mute Unta's emotes. Really.
 
 ShutUpUnta.lua


### PR DESCRIPTION
Simply tag a commit with something similar to a version number to release a new version. Version number is set automatically in toc file.

TODO: Create GitHub action secrets CF_API_KEY and WOWI_API_TOKEN via links provided here: https://github.com/BigWigsMods/packager#uploading